### PR TITLE
Simplify object parsing

### DIFF
--- a/git-parsers.js
+++ b/git-parsers.js
@@ -1,21 +1,18 @@
 const tdUtf8 = new TextDecoder("utf-8");
 
-function parseCommit(raw) {
-  const { type, body } = parseObjectHeader(raw);
-  console.assert(type == "commit");
-  return parseCommitBody(body);
+function parseCommit(obj) {
+  console.assert(obj.type == "commit");
+  return parseCommitBody(obj.body);
 }
 
-function parseTree(raw) {
-  const { type, body } = parseObjectHeader(raw);
-  console.assert(type == "tree");
-  return parseTreeBody(body);
+function parseTree(obj) {
+  console.assert(obj.type == "tree");
+  return parseTreeBody(obj.body);
 }
 
-function parseBlob(raw) {
-  const { type, body } = parseObjectHeader(raw);
-  console.assert(type == "blob");
-  return tdUtf8.decode(body);
+function parseBlob(obj) {
+  console.assert(obj.type == "blob");
+  return tdUtf8.decode(obj.body);
 }
 
 // AI-generated Git helpers. Would use Gitwit (https://github.com/PlutoLang/gitwit) but Pluto maybe a bit too heavy of a dependency right now.
@@ -39,6 +36,12 @@ function parseObjectHeader(raw) {
 
   return { type, size, body };
 }
+
+const TYPE_NAMES = {
+  1: "commit",
+  2: "tree",
+  3: "blob",
+};
 
 /**
  * Convert 20 bytes at offset to a 40-hex SHA-1 string.
@@ -211,11 +214,8 @@ async function readPackObject(buf, offset, sorted_offsets) {
       dist = ((dist + 1) << 7) + (byte & 0x7f);
     }
     const baseOffset = offset - dist;
-    //console.log("Delta, base at " + baseOffset);
     base = await readPackObject(buf, baseOffset, sorted_offsets);
-    //console.log(base);
-  }
-  else if (type == 7) {
+  } else if (type == 7) {
     throw new Error(`OBJ_REF_DELTA is not supported right now`);
   }
 
@@ -223,7 +223,7 @@ async function readPackObject(buf, offset, sorted_offsets) {
   // This avoids the “junk after end” error.
   const compressedSlice = u8.subarray(i, nextOffset);
   const ds = new DecompressionStream("deflate");
-  const reader = ds.readable.getReader()
+  const reader = ds.readable.getReader();
   const writer = ds.writable.getWriter();
 
   const readPromise = (async () => {
@@ -252,10 +252,13 @@ async function readPackObject(buf, offset, sorted_offsets) {
 
   let data = await readPromise;
   if (type == 6) {
-    type = base.typeid;
-    data = applyGitDelta(base.raw_data, data, length);
+    data = applyGitDelta(base.body, data, length);
+    return { type: base.type, size: length, body: data };
   }
-  return { typeid: type, raw_data: data };
+
+  const typeName = TYPE_NAMES[type];
+  if (!typeName) throw new Error(`Unknown/unsupported typeid ${type}`);
+  return { type: typeName, size: length, body: data };
 }
 
 function applyGitDelta(base, delta, expectedOutSize) {
@@ -338,20 +341,3 @@ function applyGitDelta(base, delta, expectedOutSize) {
   return out;
 }
 
-const TYPE_NAMES = {
-  1: "commit",
-  2: "tree",
-  3: "blob",
-};
-
-function buildObject({ typeid, raw_data }) {
-  const type = TYPE_NAMES[typeid];
-  if (!type) throw new Error(`Unknown/unsupported typeid ${typeid}`);
-  const header = `${type} ${raw_data.length}\0`;
-  const enc = new TextEncoder();
-  const headBytes = enc.encode(header);
-  const out = new Uint8Array(headBytes.length + raw_data.length);
-  out.set(headBytes, 0);
-  out.set(raw_data, headBytes.length);
-  return out;
-}

--- a/git-parsers.js
+++ b/git-parsers.js
@@ -17,10 +17,6 @@ function parseBlob(obj) {
 
 // AI-generated Git helpers. Would use Gitwit (https://github.com/PlutoLang/gitwit) but Pluto maybe a bit too heavy of a dependency right now.
 
-/**
- * Split a raw Git object into { type, size, body }.
- * raw: Uint8Array of "<type> <size>\0<body>"
- */
 function parseObjectHeader(raw) {
   let nul = 0;
   while (nul < raw.length && raw[nul] !== 0x00) nul++;
@@ -34,7 +30,7 @@ function parseObjectHeader(raw) {
 
   console.assert(Number.isFinite(size) && size === body.length);
 
-  return { type, size, body };
+  return { type, body };
 }
 
 const TYPE_NAMES = {
@@ -55,11 +51,6 @@ function sha1HexAt(bytes, offset) {
   return out;
 }
 
-/**
- * Binary-safe tree parser.
- * Accepts a Uint8Array body of a 'tree' object (NOT including the "<type> <size>\0" header).
- * Returns [{ mode, name, hash }, ...]
- */
 function parseTreeBody(body) {
   const files = [];
   let i = 0;
@@ -261,7 +252,7 @@ async function readPackObject(buf, offset, sorted_offsets) {
 
   const typeName = TYPE_NAMES[type];
   if (!typeName) throw new Error(`Unknown/unsupported typeid ${type}`);
-  return { type: typeName, size: length, body: data };
+  return { type: typeName, body: data };
 }
 
 function applyGitDelta(base, delta, expectedOutSize) {

--- a/git-parsers.js
+++ b/git-parsers.js
@@ -214,8 +214,11 @@ async function readPackObject(buf, offset, sorted_offsets) {
       dist = ((dist + 1) << 7) + (byte & 0x7f);
     }
     const baseOffset = offset - dist;
+    //console.log("Delta, base at " + baseOffset);
     base = await readPackObject(buf, baseOffset, sorted_offsets);
-  } else if (type == 7) {
+    //console.log(base);
+  }
+  else if (type == 7) {
     throw new Error(`OBJ_REF_DELTA is not supported right now`);
   }
 

--- a/script.js
+++ b/script.js
@@ -413,12 +413,11 @@ function getRawObject(hash) {
       }
       fetch(repo.url + "/objects/" + hash.substr(0, 2) + "/" + hash.substr(2)).then(async response => {
         if (response.status != 404) {
-          const data = new Uint8Array(
+          rawObjects[hash] = parseObjectHeader(new Uint8Array(
             await new Response(
               response.body.pipeThrough(new DecompressionStream("deflate")),
             ).arrayBuffer(),
-          );
-          rawObjects[hash] = parseObjectHeader(data);
+          ));
           delete pendingObjects[hash];
           updateStatus();
           return resolve(rawObjects[hash]);

--- a/script.js
+++ b/script.js
@@ -403,8 +403,8 @@ function getRawObject(hash) {
               data.pack = fetch(repo.url + "/objects/pack/" + name).then(x => x.arrayBuffer());
             }
             data.pack = await data.pack;
-            rawObjects[hash] = buildObject(await readPackObject(data.pack, data.idx.offsets[hash], data.idx.sorted_offsets));
-            //console.log(new TextDecoder("utf-8").decode(rawObjects[hash]));
+            rawObjects[hash] = await readPackObject(data.pack, data.idx.offsets[hash], data.idx.sorted_offsets);
+            //console.log(new TextDecoder("utf-8").decode(rawObjects[hash].body));
             delete pendingObjects[hash];
             updateStatus();
             return resolve(rawObjects[hash]);
@@ -413,11 +413,12 @@ function getRawObject(hash) {
       }
       fetch(repo.url + "/objects/" + hash.substr(0, 2) + "/" + hash.substr(2)).then(async response => {
         if (response.status != 404) {
-          rawObjects[hash] = new Uint8Array(
+          const data = new Uint8Array(
             await new Response(
               response.body.pipeThrough(new DecompressionStream("deflate")),
             ).arrayBuffer(),
           );
+          rawObjects[hash] = parseObjectHeader(data);
           delete pendingObjects[hash];
           updateStatus();
           return resolve(rawObjects[hash]);
@@ -452,8 +453,8 @@ function getRawObject(hash) {
               data.pack = fetch(repo.url + "/objects/pack/" + name).then(x => x.arrayBuffer());
             }
             data.pack = await data.pack;
-            rawObjects[hash] = buildObject(await readPackObject(data.pack, data.idx.offsets[hash], data.idx.sorted_offsets));
-            //console.log(new TextDecoder("utf-8").decode(rawObjects[hash]));
+            rawObjects[hash] = await readPackObject(data.pack, data.idx.offsets[hash], data.idx.sorted_offsets);
+            //console.log(new TextDecoder("utf-8").decode(rawObjects[hash].body));
             delete pendingObjects[hash];
             updateStatus();
             return resolve(rawObjects[hash]);


### PR DESCRIPTION
## Summary
- Return parsed `{type, size, body}` from packfiles instead of constructing full objects
- Parse commit/tree/blob directly from parsed objects
- Cache loose objects as parsed headers rather than raw bytes

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check git-parsers.js`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a164f07a608325ad1ffd585e4fecbc